### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Implement API Gateway Throttling Configuration

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -127,12 +127,14 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             removal_policy=RemovalPolicy.DESTROY,
         )
 
-        # Create API Gateway
+        # Create API Gateway with throttling configuration
         apigw_.LambdaRestApi(
             self,
             "Endpoint",
             handler=api_hanlder,
             deploy_options=apigw_.StageOptions(
+                throttling_rate_limit=1000,
+                throttling_burst_limit=2000,
                 tracing_enabled=True,
                 access_log_destination=apigw_.LogGroupLogDestination(api_log_group),
                 access_log_format=apigw_.AccessLogFormat.json_with_standard_fields(


### PR DESCRIPTION
## Summary

This PR implements API Gateway throttling configuration addressing AWS Well-Architected Framework best practice REL05-BP02 (Throttle requests). The changes add explicit rate limiting and burst capacity controls to protect the API from request exhaustion during traffic spikes, retry storms, or flooding attacks.

Fixes #5

## Changes Made

### API Gateway Throttling Configuration
- Added `throttling_rate_limit=1000` (requests per second) to API Gateway stage
- Added `throttling_burst_limit=2000` (burst capacity) to API Gateway stage
- Throttling configured at stage level to apply to all API methods

## Well-Architected Framework Compliance

These changes implement REL05-BP02 throttling controls to mitigate resource exhaustion from unexpected demand increases. Without throttling, sudden traffic spikes could overwhelm backend resources and cause service degradation for all users.

✅ **Request Rate Control**: API Gateway now enforces 1000 requests/second steady-state limit
✅ **Burst Protection**: Burst capacity of 2000 requests handles short traffic spikes
✅ **Automatic Throttling**: Requests exceeding limits receive HTTP 429 responses
✅ **Resource Protection**: Backend Lambda and DynamoDB protected from overload

## Testing

After deployment:
1. Test normal API requests continue to work
2. Use load testing tools to verify throttling activates at configured limits
3. Confirm HTTP 429 responses are returned when limits exceeded
4. Monitor CloudWatch metrics for throttled request counts

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added throttling configuration to API Gateway stage options