### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Configure Lambda Reserved Concurrency to Prevent Resource Exhaustion

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -113,6 +113,7 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             timeout=Duration.minutes(5),
             tracing=lambda_.Tracing.ACTIVE,
             log_retention=logs.RetentionDays.ONE_YEAR,
+            reserved_concurrent_executions=100,
         )
 
         # grant permission to lambda to write to demo table


### PR DESCRIPTION
## Summary

This PR configures Lambda reserved concurrency to prevent account-level concurrency exhaustion during traffic spikes, addressing AWS Well-Architected Framework best practice REL05-BP02 (Throttle requests). This provides defense-in-depth throttling at the compute layer.

Fixes #8

## Changes Made

### Lambda Reserved Concurrency Configuration
- Added `reserved_concurrent_executions=100` to Lambda function
- Ensures this function cannot consume all account concurrency
- Protects other Lambda functions in the same account/region from resource starvation

## Well-Architected Framework Compliance

These changes implement compute-layer throttling to prevent a single Lambda function from exhausting account-level concurrency limits. This is a defense-in-depth measure that complements API Gateway throttling.

✅ **Concurrency Isolation**: Function limited to 100 concurrent executions
✅ **Account Protection**: Other Lambda functions protected from resource starvation
✅ **Predictable Behavior**: Consistent performance under traffic spikes
✅ **Resource Allocation**: Explicit capacity reservation for this workload

## Testing

After deployment:
1. Verify API continues to function normally
2. Monitor Lambda ConcurrentExecutions metric in CloudWatch
3. Test behavior when concurrent executions approach the limit
4. Confirm other Lambda functions in account are not impacted during load tests
5. Validate reserved concurrency aligns with expected traffic patterns

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added reserved_concurrent_executions parameter to Lambda function