### PR TITLE
[ARC302 Well-Architected] REL05-BP02: Configure DynamoDB Billing Mode for Throttling Control

### DIFF
--- a/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
+++ b/python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py
@@ -93,6 +93,7 @@ class ApigwHttpApiLambdaDynamodbPythonCdkStack(Stack):
             partition_key=dynamodb_.Attribute(
                 name="id", type=dynamodb_.AttributeType.STRING
             ),
+            billing_mode=dynamodb_.BillingMode.PAY_PER_REQUEST,
             point_in_time_recovery=True,
             contributor_insights_enabled=True,
         )


### PR DESCRIPTION
## Summary

This PR adds explicit DynamoDB billing mode configuration to document the throttling strategy at the database layer, addressing AWS Well-Architected Framework best practice REL05-BP02 (Throttle requests). The on-demand billing mode provides automatic scaling with built-in capacity limits.

Fixes #9

## Changes Made

### DynamoDB Billing Mode Configuration
- Added explicit `billing_mode=dynamodb_.BillingMode.PAY_PER_REQUEST` to DynamoDB table
- Documents the use of on-demand capacity mode for automatic scaling
- On-demand mode provides 40,000 read and 40,000 write request units per table

## Well-Architected Framework Compliance

These changes explicitly configure DynamoDB's throttling behavior through billing mode selection. On-demand mode automatically scales to handle traffic spikes while maintaining built-in capacity limits that protect the database layer.

✅ **Explicit Configuration**: Billing mode is now clearly documented in code
✅ **Automatic Scaling**: On-demand mode handles traffic variations without manual intervention
✅ **Built-in Limits**: 40,000 read/write request units per table provide throttling protection
✅ **Simplified Operations**: No capacity planning required for variable workloads

## Testing

After deployment:
1. Verify DynamoDB table is created with on-demand billing mode
2. Test API write operations continue to function normally
3. Monitor DynamoDB CloudWatch metrics for consumed capacity
4. Validate no throttling occurs under expected load conditions
5. Review AWS billing to confirm on-demand pricing model

## Files Modified

- `python/apigw-http-api-lambda-dynamodb-python-cdk/stacks/apigw_http_api_lambda_dynamodb_python_cdk_stack.py` - Added billing_mode parameter to DynamoDB table configuration